### PR TITLE
fix dye tags in shulker block recipes

### DIFF
--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/black_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/black_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/black"
+      "tag": "c:dyes/black"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/blue_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/blue_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/blue"
+      "tag": "c:dyes/blue"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/brown_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/brown_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/brown"
+      "tag": "c:dyes/brown"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/cyan_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/cyan_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/cyan"
+      "tag": "c:dyes/cyan"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/gray_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/gray_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/gray"
+      "tag": "c:dyes/gray"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/green_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/green_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/green"
+      "tag": "c:dyes/green"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/light_blue_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/light_blue_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/light_blue"
+      "tag": "c:dyes/light_blue"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/light_gray_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/light_gray_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/light_gray"
+      "tag": "c:dyes/light_gray"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/lime_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/lime_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/lime"
+      "tag": "c:dyes/lime"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/magenta_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/magenta_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/magenta"
+      "tag": "c:dyes/magenta"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/orange_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/orange_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/orange"
+      "tag": "c:dyes/orange"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/pink_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/pink_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/pink"
+      "tag": "c:dyes/pink"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/purple_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/purple_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/purple"
+      "tag": "c:dyes/purple"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/red_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/red_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/red"
+      "tag": "c:dyes/red"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/white_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/white_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/white"
+      "tag": "c:dyes/white"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_block/yellow_shulker_block.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_block/yellow_shulker_block.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_block"
     },
     "X": {
-      "tag": "forge:dyes/yellow"
+      "tag": "c:dyes/yellow"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/black_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/black_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/black"
+      "tag": "c:dyes/black"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/blue_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/blue_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/blue"
+      "tag": "c:dyes/blue"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/brown_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/brown_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/brown"
+      "tag": "c:dyes/brown"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/cyan_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/cyan_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/cyan"
+      "tag": "c:dyes/cyan"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/gray_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/gray_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/gray"
+      "tag": "c:dyes/gray"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/green_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/green_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/green"
+      "tag": "c:dyes/green"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/light_blue_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/light_blue_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/light_blue"
+      "tag": "c:dyes/light_blue"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/light_gray_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/light_gray_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/light_gray"
+      "tag": "c:dyes/light_gray"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/lime_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/lime_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/lime"
+      "tag": "c:dyes/lime"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/magenta_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/magenta_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/magenta"
+      "tag": "c:dyes/magenta"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/orange_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/orange_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/orange"
+      "tag": "c:dyes/orange"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/pink_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/pink_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/pink"
+      "tag": "c:dyes/pink"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/purple_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/purple_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/purple"
+      "tag": "c:dyes/purple"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/red_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/red_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/red"
+      "tag": "c:dyes/red"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/white_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/white_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/white"
+      "tag": "c:dyes/white"
     }
   },
   "result": {

--- a/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/yellow_shulker_swirl.json
+++ b/src/main/resources/data/addendum/recipe/crafting/shulker_swirl/yellow_shulker_swirl.json
@@ -11,7 +11,7 @@
       "item": "addendum:shulker_swirl"
     },
     "X": {
-      "tag": "forge:dyes/yellow"
+      "tag": "c:dyes/yellow"
     }
   },
   "result": {


### PR DESCRIPTION
migrates the namespace of the referenced dye tags in the shulker block recipes from `forge` to `c`, as neoforge does not use `forge` for it's common tags